### PR TITLE
include colgroups in the fixed header table

### DIFF
--- a/js/FixedHeader.js
+++ b/js/FixedHeader.js
@@ -692,6 +692,10 @@ FixedHeader.prototype = {
 			nTable.removeChild( nTable.childNodes[0] );
 		}
 
+		/* Clone the colgroups */
+		var nColgroup = $('colgroup', s.nTable).clone(true);
+		$(nTable).append( nColgroup );
+
 		/* Clone the DataTables header */
 		var nThead = $('thead', s.nTable).clone(true)[0];
 		nTable.appendChild( nThead );
@@ -967,5 +971,4 @@ $(window).scroll( function () {
 
 
 }(window, document, jQuery));
-
 


### PR DESCRIPTION
The tables I am working with use colgroups and css to style the column colors.  But this gets lost in the headers once they become `fixed`.

So I clone the colgroups as before the headers.

I am not very familiar with the FixedHeader api, so this probably is not the best way to implement.  
