### PR TITLE
Eliminating extra td elements in thead with 'left' or 'right' options

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -812,6 +812,7 @@ FixedHeader.prototype = {
 		var sSelector = 'gt(' + (oCache.iCells - 1) + ')';
 		$('thead tr', nTable).each( function (k) {
 			$('th:' + sSelector, this).remove();
+			$('td:' + sSelector, this).remove();
 		} );
 
 		$('tfoot tr', nTable).each( function (k) {
@@ -861,6 +862,7 @@ FixedHeader.prototype = {
 			nTable.appendChild( $("tfoot", s.nTable).clone(true)[0] );
 		}
 		$('thead tr th:lt('+(iCols-oCache.iCells)+')', nTable).remove();
+		$('thead tr td:lt('+(iCols-oCache.iCells)+')', nTable).remove();
 		$('tfoot tr th:lt('+(iCols-oCache.iCells)+')', nTable).remove();
 
 		/* Remove unneeded cells */


### PR DESCRIPTION
Suppose that I have a table with two rows in thead.  As far as I know, one suggested practice in this case is to use td elements in one row, like:

```
<thead>
    <tr class="col-nums">
        <td>1</td>
        <td>2</td>
        <td>3</td>
    </tr>
    <tr class="col-names">
        <th>Name1</th>
        <th>Name2</th>
        <th>Name3</th>
    </tr>
</thead>
```

Fixing the left or right two columns, for example, would be accomplished with:
new FixedHeader(table, {"left": 2});
new FixedHeader(table, {"right": 2});

Unfortunately, FixedHeader fails to remove the extra td elements in this case.  The fix seems to be straightforward.
