### PR TITLE
Outer width fix

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -384,7 +384,7 @@ FixedHeader.prototype = {
 			iParentScrollTop = this._fnSumScroll( s.nTable.parentNode, 'scrollTop' ),
 			iParentScrollLeft = this._fnSumScroll( s.nTable.parentNode, 'scrollLeft' );
 
-		m.iTableWidth = jqTable.outerWidth();
+		m.iTableWidth = jqTable.outerWidth(true);
 		m.iTableHeight = jqTable.outerHeight();
 		m.iTableLeft = oOffset.left + s.nTable.parentNode.scrollLeft;
 		m.iTableTop = oOffset.top + iParentScrollTop;
@@ -492,7 +492,7 @@ FixedHeader.prototype = {
 			oWin = FixedHeader.oWin,
 			oDoc = FixedHeader.oDoc,
 			nTable = oCache.nWrapper,
-			iFixedWidth = $(nTable).outerWidth();
+			iFixedWidth = $(nTable).outerWidth(true);
 
 		if ( oWin.iScrollRight < oMes.iTableRight )
 		{
@@ -531,7 +531,7 @@ FixedHeader.prototype = {
 			oWin = FixedHeader.oWin,
 			oDoc = FixedHeader.oDoc,
 			nTable = oCache.nWrapper,
-			iCellWidth = $(nTable).outerWidth();
+			iCellWidth = $(nTable).outerWidth(true);
 
 		if ( oWin.iScrollLeft < oMes.iTableLeft )
 		{
@@ -704,7 +704,7 @@ FixedHeader.prototype = {
 		}
 
 		/* Set the wrapper width to match that of the cloned table */
-		var iDtWidth = $(s.nTable).outerWidth();
+		var iDtWidth = $(s.nTable).outerWidth(true);
 		oCache.nWrapper.style.width = iDtWidth+"px";
 		nTable.style.width = iDtWidth+"px";
 
@@ -760,7 +760,7 @@ FixedHeader.prototype = {
 		var nTable = oCache.nNode;
 
 		/* Set the wrapper width to match that of the cloned table */
-		oCache.nWrapper.style.width = $(s.nTable).outerWidth()+"px";
+		oCache.nWrapper.style.width = $(s.nTable).outerWidth(true)+"px";
 
 		/* Remove any children the cloned table has */
 		while ( nTable.childNodes.length > 0 )
@@ -828,7 +828,7 @@ FixedHeader.prototype = {
 
 		var iWidth = 0;
 		for (var i = 0; i < oCache.iCells; i++) {
-			iWidth += $('thead tr th:eq(' + i + ')', s.nTable).outerWidth();
+			iWidth += $('thead tr th:eq(' + i + ')', s.nTable).outerWidth(true);
 		}
 		nTable.style.width = iWidth+"px";
 		oCache.nWrapper.style.width = iWidth+"px";
@@ -874,7 +874,7 @@ FixedHeader.prototype = {
 
 		var iWidth = 0;
 		for (var i = 0; i < oCache.iCells; i++) {
-			iWidth += $('thead tr th:eq('+(iCols-1-i)+')', s.nTable).outerWidth();
+			iWidth += $('thead tr th:eq('+(iCols-1-i)+')', s.nTable).outerWidth(true);
 		}
 		nTable.style.width = iWidth+"px";
 		oCache.nWrapper.style.width = iWidth+"px";


### PR DESCRIPTION
Guys, please consider replacing ```outerWidth()``` with ```outerWidth(true)``` or ```width()```. I've experienced some examples where method call with no parameters have returned object itself and it caused errors.
![outerwidth](https://cloud.githubusercontent.com/assets/1309389/3259848/a314a2e0-f247-11e3-8a06-31cb9432ae44.png)
