### PR TITLE
Fixed version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "datatables-fixedheader",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"main": [
 		"js/dataTables.fixedHeader.js",
 		"css/dataTables.fixedHeader.css"


### PR DESCRIPTION
Fixed the version:

> bower mismatch      Version declared in the json (2.1.0) is different than the resolved one (2.1.1)
