### PR TITLE
Added some initialization options

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -54,6 +54,11 @@ var factory = function( $, DataTable ) {
  *    * int:zBottom - fixed footer zIndex
  *    * int:zLeft -   fixed left zIndex
  *    * int:zRight -  fixed right zIndex
+ *    * bool:alwaysCloneBottom
+ *    * bool:alwaysCloneLeft
+ *    * bool:alwaysCloneRight
+ *    * bool:alwaysCloneTop
+ *    * int:offsetTop
  */
 FixedHeader = function ( mTable, oInit ) {
 	/* Sanity check - you just know it will happen */


### PR DESCRIPTION
Discovered them by browsing the source, documentation might be nice. 

Setting "alwaysCloneTop" to true fixed an issue we had with sorting a DataTable in combination with the FixedHeader plugin. Setting it to false broke the sorting functionality again...