### PR TITLE
Add event handlers to resize and position headers

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -269,6 +269,17 @@ FixedHeader.prototype = {
 				that._fnUpdateClones( true );
 				that._fnUpdatePositions();
 			} )
+			.on('init.dt' + this._eventNamespace, function () {
+				FixedHeader.fnMeasure();
+				that._fnUpdateClones( true );
+				that._fnUpdatePositions();
+			} )
+			.on('draw.dt' + this._eventNamespace, function () {
+				FixedHeader.fnMeasure();
+				for ( var i=0, iLen=FixedHeader.afnScroll.length ; i<iLen ; i++ ) {
+					FixedHeader.afnScroll[i]();
+				}
+			} )
 			.on('destroy.dt' + this._eventNamespace, function () {
 				that._fnRemoveEventHandlers();
 				that._fnRemoveElements();


### PR DESCRIPTION
`init.dt` allows header column sizes to respond to size changes due to ajax data

With multiple DataTables on a page, `draw.dt` allows headers to
reposition after ajax data has loaded (fixes vertical positioning
before scrolling) and after searching changes the number of displayed
rows (occurs after scroll has fired at least once)

The issues can be seen in [this jsFiddle](https://jsfiddle.net/p1hsaj9u/).  Make sure not to scroll to see the second tables header over the first table.  Then scroll, and search for something that isn't in the first table and you will see the second tables header is now out of position.

[This jsFiddle](https://jsfiddle.net/xox14p85/) shows the result of this pull request. Not perfect, but a step in the right direction.

This seems to address issue #49.