### PR TITLE
Fix namespace closure.

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -154,9 +154,10 @@ $.extend( FixedHeader.prototype, {
 				that._scroll();
 			} );
 
+            var closureNamespace = this.s.namespace;
 		dt.on( 'destroy.dtfc', function () {
 			dt.off( '.dtfc' );
-			$(window).off( that.s.namespace );
+			$(window).off( closureNamespace );
 		} );
 
 		this._positions();


### PR DESCRIPTION
On Chrome, the following causes an exception:
```
$('#example').DataTable({
                 destroy: true,
                 dom: "tlp",
                 fixedHeader: {
                     header: true
                 }
             });
```
The 'that.s.namespace' reference in FixedHeader fails because 's' does not exist.  This patch replaces 'that.s.namespace' with a simple variable, which does work.