### PR TITLE
Added headerOffset API to change headerOffset dynamically

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -154,6 +154,17 @@ $.extend( FixedHeader.prototype, {
   {
 		this.c.headerOffset = topOffset;
   },
+  
+  /**
+   * Set footerOffset 
+   *
+   * @param  {int} new value for footerOffset
+   */
+  footerOffset: function ( bottomOffset )
+  {
+    this.c.footerOffset = bottomOffset;
+  },
+
 	
 	/**
 	 * Recalculate the position of the fixed elements and force them into place
@@ -593,6 +604,33 @@ DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
 
     if ( fh ) {
       fh.headerOffset( topOffset );
+    }
+  } );
+} );
+
+/**
+ * Get the current footerOffset.
+ *
+ * @return {integer} the offset (in pixels) of the footer element's offset for the scrolling calculations
+ *
+ *//**
+ * Set the footerOffset.
+ *
+ * @param {integer} bottomOffset - the offset (in pixels) of the footer element's offset for the scrolling calculations
+ * @returns {DataTables.Api} this
+ */
+
+DataTable.Api.register( 'fixedHeader.footerOffset()', function ( bottomOffset ) {
+  if ( bottomOffset === undefined ) {
+    return this.context.length !== 0 ?
+           this.context[0]._fixedHeader.c.footerOffset :
+           undefined;
+  }
+  return this.iterator( 'table', function ( ctx ) {
+    var fh = ctx._fixedHeader;
+
+    if ( fh ) {
+      fh.footerOffset( bottomOffset );
     }
   } );
 } );

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -571,14 +571,30 @@ DataTable.Api.register( 'fixedHeader.disable()', function ( ) {
 	} );
 } );
 
+/**
+ * Get the current headerOffset.
+ *
+ * @return {integer} the offset (in pixels) of the header element's offset for the scrolling calculations
+ *
+ *//**
+ * Set the headerOffset.
+ *
+ * @param {integer} topOffset - the offset (in pixels) of the header element's offset for the scrolling calculations
+ * @returns {DataTables.Api} this
+ */
 DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
-	return this.iterator( 'table', function ( ctx ) {
-		var fh = ctx._fixedHeader;
+  if ( topOffset === undefined ) {
+    return this.context.length !== 0 ?
+           this.context[0]._fixedHeader.c.headerOffset :
+           undefined;
+  }
+  return this.iterator( 'table', function ( ctx ) {
+    var fh = ctx._fixedHeader;
 
-		if ( fh ) {
-			fh.headerOffset( topOffset );
-		}
-	} );
+    if ( fh ) {
+      fh.headerOffset( topOffset );
+    }
+  } );
 } );
 
 return FixedHeader;

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -154,7 +154,17 @@ $.extend( FixedHeader.prototype, {
   {
 		this.c.headerOffset = topOffset;
   },
-	
+  
+  /**
+   * Set footerOffset 
+   *
+   * @param  {int} new value for footerOffset
+   */
+  footerOffset: function ( bottomOffset )
+  {
+    this.c.footerOffset = bottomOffset;
+  },	
+
 	/**
 	 * Recalculate the position of the fixed elements and force them into place
 	 */
@@ -593,6 +603,33 @@ DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
 
     if ( fh ) {
       fh.headerOffset( topOffset );
+    }
+  } );
+} );
+
+/**
+ * Get the current footerOffset.
+ *
+ * @return {integer} the offset (in pixels) of the footer element's offset for the scrolling calculations
+ *
+ *//**
+ * Set the footerOffset.
+ *
+ * @param {integer} bottomOffset - the offset (in pixels) of the footer element's offset for the scrolling calculations
+ * @returns {DataTables.Api} this
+ */
+
+DataTable.Api.register( 'fixedHeader.footerOffset()', function ( bottomOffset ) {
+  if ( bottomOffset === undefined ) {
+    return this.context.length !== 0 ?
+           this.context[0]._fixedHeader.c.footerOffset :
+           undefined;
+  }
+  return this.iterator( 'table', function ( ctx ) {
+    var fh = ctx._fixedHeader;
+
+    if ( fh ) {
+      fh.footerOffset( bottomOffset );
     }
   } );
 } );

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -154,17 +154,7 @@ $.extend( FixedHeader.prototype, {
   {
 		this.c.headerOffset = topOffset;
   },
-  
-  /**
-   * Set footerOffset 
-   *
-   * @param  {int} new value for footerOffset
-   */
-  footerOffset: function ( bottomOffset )
-  {
-    this.c.footerOffset = bottomOffset;
-  },	
-
+	
 	/**
 	 * Recalculate the position of the fixed elements and force them into place
 	 */
@@ -603,33 +593,6 @@ DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
 
     if ( fh ) {
       fh.headerOffset( topOffset );
-    }
-  } );
-} );
-
-/**
- * Get the current footerOffset.
- *
- * @return {integer} the offset (in pixels) of the footer element's offset for the scrolling calculations
- *
- *//**
- * Set the footerOffset.
- *
- * @param {integer} bottomOffset - the offset (in pixels) of the footer element's offset for the scrolling calculations
- * @returns {DataTables.Api} this
- */
-
-DataTable.Api.register( 'fixedHeader.footerOffset()', function ( bottomOffset ) {
-  if ( bottomOffset === undefined ) {
-    return this.context.length !== 0 ?
-           this.context[0]._fixedHeader.c.footerOffset :
-           undefined;
-  }
-  return this.iterator( 'table', function ( ctx ) {
-    var fh = ctx._fixedHeader;
-
-    if ( fh ) {
-      fh.footerOffset( bottomOffset );
     }
   } );
 } );

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -146,6 +146,16 @@ $.extend( FixedHeader.prototype, {
 	},
 	
 	/**
+	 * Set headerOffset 
+	 *
+	 * @param  {int} new value for headerOffset
+	 */
+	headerOffset: function ( topOffset )
+  {
+		this.c.headerOffset = topOffset;
+  },
+	
+	/**
 	 * Recalculate the position of the fixed elements and force them into place
 	 */
 	update: function ()
@@ -561,6 +571,15 @@ DataTable.Api.register( 'fixedHeader.disable()', function ( ) {
 	} );
 } );
 
+DataTable.Api.register( 'fixedHeader.headerOffset()', function ( topOffset ) {
+	return this.iterator( 'table', function ( ctx ) {
+		var fh = ctx._fixedHeader;
+
+		if ( fh ) {
+			fh.headerOffset( topOffset );
+		}
+	} );
+} );
 
 return FixedHeader;
 }));


### PR DESCRIPTION
For the cases when headerOffset of an existing fixedHeader need to be
changed, introduced headerOffset() API.
Usage:  table.fixedHeader.headerOffset( topOffset );