### PR TITLE
Fixed? the _unsize function to use 'min-width' instead of 'width'

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -326,7 +326,7 @@ $.extend( FixedHeader.prototype, {
 		var el = this.dom[ item ].floating;
 
 		if ( el && (item === 'footer' || (item === 'header' && ! this.s.autoWidth)) ) {
-			$('th, td', el).css( 'width', '' );
+			$('th, td', el).css( 'min-width', '' );
 		}
 	},
 


### PR DESCRIPTION
In the '_unsize' function the 'width' property of the td and th elements is reset while in the '_matchWidths' function the 'min_width' property of these elements is set. This causes a problem if the header is reinjected into the html table as the width values that were set by FixedHeader remain and prevent a proper resizing of the table.
This pull request fixes the issue by changing the '_unsize' function to reset the 'min-width' property.