### PR TITLE
Calling the '_unsize' function when the headers are re-cloned ...

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -262,6 +262,7 @@ $.extend( FixedHeader.prototype, {
 		}
 		else {
 			if ( itemDom.floating ) {
+				this._unsize( item );
 				itemDom.placeholder.remove();
 				itemDom.floating.children().detach();
 				itemDom.floating.remove();


### PR DESCRIPTION
... to remove the width definitions from the cells.

 This way the cell with is redetermined by the original table before the cells are re-cloned for the header, allowing a shinking of the cells.

Works for me only in conjunction with pull request #75. But as the original functionality of `_unsize` could be correct I put this fix in a different Pull Request.

Fixes #76 
