### PR TITLE
Calling enable() or disable() will only update header if status is changing

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -635,8 +635,9 @@ DataTable.Api.register( 'fixedHeader.enable()', function ( flag ) {
 	return this.iterator( 'table', function ( ctx ) {
 		var fh = ctx._fixedHeader;
 
-		if ( fh ) {
-			fh.enable( flag !== undefined ? flag : true );
+		flag = ( flag !== undefined ? flag : true );
+		if ( fh && flag !== fh.s.enable ) {
+			fh.enable( flag );
 		}
 	} );
 } );
@@ -645,7 +646,7 @@ DataTable.Api.register( 'fixedHeader.disable()', function ( ) {
 	return this.iterator( 'table', function ( ctx ) {
 		var fh = ctx._fixedHeader;
 
-		if ( fh ) {
+		if ( fh && fh.s.enable ) {
 			fh.enable( false );
 		}
 	} );


### PR DESCRIPTION
The motivating factor for this change is that the public API does not expose a property or method that returns whether or not the FixedHeader instance is enabled. (i.e. `fixedHeader.isEnabled()`)

Rather than adding an `isEnabled()` function to the public API, it seemed more appropriate to simply limit the amount of work done by the `enable()` and `disable()` functions.

For example,
- When the fixed header is disabled, calling `disable()` should not do any work.
- When the fixed header is enabled, calling `enable()` should not do any work.