### PR TITLE
Sticky header/footer for non-body scroll elements. 

### DIFF
--- a/css/fixedHeader.dataTables.scss
+++ b/css/fixedHeader.dataTables.scss
@@ -12,6 +12,7 @@ table.fixedHeader-floating.no-footer {
 table.fixedHeader-locked {
 	position: absolute !important;
 	background-color: white;
+	margin: 0 !important;
 }
 
 @media print {

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -384,6 +384,32 @@ $.extend( FixedHeader.prototype, {
 			lastScrollLeft[ item ] = scrollLeft;
 		}
 	},
+	
+	/** 
+	 * Get the closest ancestor element that is scrollable. 
+	 * @private
+	 */ 
+	_scrollParent: function( element ) 
+	{
+		// based on the jQuery UI version of scrollParent()
+		// Copyright jQuery Foundation and other contributors
+		// Released under the MIT license.
+		var position = element.css( "position" ),
+			excludeStaticParent = position === "absolute",
+			overflowRegex = /(auto|scroll)/,
+			scrollParent = element.parents().filter( function() {
+				var parent = $( this );
+				if ( excludeStaticParent && parent.css( "position" ) === "static" ) {
+					return false;
+				}
+				return overflowRegex.test( parent.css( "overflow" ) + parent.css( "overflow-y" ) +
+					parent.css( "overflow-x" ) );
+			} ).eq( 0 );
+
+		return position === "fixed" || !scrollParent.length ?
+			$( element[ 0 ].ownerDocument || document ) :
+			scrollParent;		
+	},
 
 	/**
 	 * Change from one display mode to another. Each fixed item can be in one
@@ -503,7 +529,7 @@ $.extend( FixedHeader.prototype, {
 		var position = this.s.position;
 		var dom = this.dom;
 		var tableNode = $(table.node());
-	    var scrollParent = tableNode.scrollParent();
+		var scrollParent = this._scrollParent(tableNode);
 
 		// Need to use the header and footer that are in the main table,
 		// regardless of if they are clones, since they hold the positions we
@@ -520,7 +546,7 @@ $.extend( FixedHeader.prototype, {
 		position.theadHeight = position.tbodyTop - position.theadTop;
 		position.scrollParentTop = scrollParent.offset().top;
 		position.scrollParentVisible = scrollParent.is(':visible');
-	    position.scrollParentHeight = scrollParent.outerHeight();
+		position.scrollParentHeight = scrollParent.outerHeight();
 
 		if ( tfoot.length ) {
 			position.tfootTop = tfoot.offset().top;

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -81,7 +81,9 @@ var FixedHeader = function ( dt, config ) {
 			tfootHeight: 0,
 			theadHeight: 0,
 			windowHeight: $(window).height(),
-			visible: true
+			visible: true,
+			scrollParentTop: 0,
+			scrollParentVisible: true
 		},
 		headerMode: null,
 		footerMode: null,
@@ -211,14 +213,18 @@ $.extend( FixedHeader.prototype, {
 		var that = this;
 		var dt = this.s.dt;
 
-		$(window)
-			.on( 'scroll'+this.s.namespace, function () {
+		window.addEventListener('scroll',
+			function () {
+				if(this.c.relativeScroll) {
+					that._positions();
+				}
 				that._scroll();
-			} )
-			.on( 'resize'+this.s.namespace, function () {
+			}, true);
+		window.addEventListener('resize',
+			function () {
 				that.s.position.windowHeight = $(window).height();
 				that.update();
-			} );
+			}, true);
 
 		var autoHeader = $('.fh-fixedHeader');
 		if ( ! this.c.headerOffset && autoHeader.length ) {
@@ -498,6 +504,8 @@ $.extend( FixedHeader.prototype, {
 		position.theadTop = thead.offset().top;
 		position.tbodyTop = tbody.offset().top;
 		position.theadHeight = position.tbodyTop - position.theadTop;
+		position.scrollParentTop = thead.scrollParent().offset().top;
+		position.scrollParentVisible = thead.scrollParent().is(':visible');
 
 		if ( tfoot.length ) {
 			position.tfootTop = tfoot.offset().top;
@@ -532,7 +540,10 @@ $.extend( FixedHeader.prototype, {
 		}
 
 		if ( this.c.header ) {
-			if ( ! position.visible || windowTop <= position.theadTop - this.c.headerOffset ) {
+			if ( this.c.relativeScroll && position.scrollParentVisible && position.theadTop - position.scrollParentTop < 0 ) {
+				headerMode = 'in-relative';
+			}
+			else if ( this.c.relativeScroll || ! position.visible || windowTop <= position.theadTop - this.c.headerOffset ) {
 				headerMode = 'in-place';
 			}
 			else if ( windowTop <= position.tfootTop - position.theadHeight - this.c.headerOffset ) {
@@ -586,7 +597,8 @@ FixedHeader.defaults = {
 	header: true,
 	footer: false,
 	headerOffset: 0,
-	footerOffset: 0
+	footerOffset: 0,
+	relativeScroll: 0
 };
 
 

--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -407,7 +407,7 @@ $.extend( FixedHeader.prototype, {
 			} ).eq( 0 );
 
 		return position === "fixed" || !scrollParent.length ?
-			$( element[ 0 ].ownerDocument || document ) :
+			$( element[ 0 ].ownerDocument.body || document.body ) :
 			scrollParent;		
 	},
 


### PR DESCRIPTION
This PR implements the feature requested in #80. When the corresponding new "relative mode" is enabled via setting the header is positioned within the next parent scrollable element. 