### PR TITLE
Fix blur/focus issue on Android phones

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -220,7 +220,7 @@ $.extend( FixedHeader.prototype, {
 		}
 
 		this._positions();
-		this._scroll( true );
+		this._scroll();
 	},
 
 


### PR DESCRIPTION
Fix for Android devices getting stuck in a focus/blur loop (or just not letting the user close the keyboard) when column filters are present.

I'm not an Apple fanboy so I do not know if this affects iOS but I would assume so.

How to reproduce issue
-----
1) Go to http://live.datatables.net/hapujuna on an Android phone
2) Scroll down so the fixed header shows up
3) Click one of the filter fields
4) Either the keyboard will start popping up and hiding already (in a blur/focus loop) or if not you can press the back button to close the soft keyboard and each time you do the keyboard goes away then comes right back.

This PR fixes this problem. It seems that the code does a force redraw when the screen size changes. When the soft keyboard pops up it actually triggers a page size change which then causes the fixedHeader to redraw causing the focus/blur stuff to happen (because the fixedHeader tries to maintain your input focus).

I don't know why we do a forced change inside the scroll event. It actually runs far better on my phone without it (since my phone doesn't have to redraw the header over and over while scrolling around).

I want to make sure I don't break things for anyone else. If someone knows why we do a `forcedChange` please do let me know why and if this will cause problems with it. Otherwise this should be good to go.