### PR TITLE
Fix: Avoid errors with tsconfig#noImplicitAny

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -40,7 +40,7 @@ declare module 'datatables.net' {
 			/**
 			 * Create a new FixedHeader instance for the target DataTable
 			 */
-			new (dt: Api<any>, settings: boolean | ConfigFixedHeader);
+			new (dt: Api<any>, settings: boolean | ConfigFixedHeader): void;
 
 			/**
 			 * FixedHeader version


### PR DESCRIPTION
I'm encountering a type error in the type definition of types/types.d.ts.

> Construct signature, which lacks return-type annotation, implicitly has an 'any' return type

```console
$ npx tsc --noEmit --noImplicitAny
node_modules/datatables.net-fixedheader/types/types.d.ts:43:4 - error TS7013: Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.

43    new (dt: Api<any>, settings: boolean | ConfigFixedHeader);
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/datatables.net-fixedheader/types/types.d.ts:43

```

This occurs when the `noImplicitAny` flag is enabled. I believe many projects might be using this setting.

I checked the documentation, and it appears that this process does not expect a return value. I've added explicit type definitions accordingly.

- [FixedHeader](https://datatables.net/extensions/fixedheader/)
