### PR TITLE
Fix: Prevent mobile focus loop

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -519,7 +519,11 @@ $.extend(FixedHeader.prototype, {
 			: null;
 		var scrollBody = $($(this.s.dt.table().node()).parent());
 
-		if (mode === 'in-place') {
+		if (mode === this.s[item + 'Mode'] && !forceChange) {
+			// Skip if already the current mode
+			return;
+		}
+		else if (mode === 'in-place') {
 			// Insert the header back into the table's real header
 			if (itemDom.placeholder) {
 				itemDom.placeholder.remove();
@@ -528,8 +532,7 @@ $.extend(FixedHeader.prototype, {
 
 			if (item === 'header') {
 				itemDom.host.prepend(tablePart);
-			}
-			else {
+			} else {
 				itemDom.host.append(tablePart);
 			}
 


### PR DESCRIPTION
Trying to fix the same issue as https://github.com/DataTables/FixedHeader/pull/104 but with a different approach.

On mobile, if the header or footer contains an input field, we have an issue where the mobile phone open and close the keyboard continuously on the input field focus.

This happens because when the keyboard opens, the `scroll` event is triggered which is the event triggering the fixer header "redraw". The focus is lost during the redraw because the dom element is moved, and then, focus is reapplied to the previous active element. Which result in an infinite loop (re focusing the input will reopen the keyboard...).

With my fix, we skip the redraw if the fixed header is already properly positioned.