### PR TITLE
Fix: Prevent mobile focus loop

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -526,11 +526,13 @@ $.extend(FixedHeader.prototype, {
 				itemDom.placeholder = null;
 			}
 
-			if (item === 'header') {
-				itemDom.host.prepend(tablePart);
-			}
-			else {
-				itemDom.host.append(tablePart);
+			if (!$.contains(itemDom.host[0], tablePart[0])) {
+				if (item === 'header') {
+					itemDom.host.prepend(tablePart);
+				}
+				else {
+					itemDom.host.append(tablePart);
+				}
 			}
 
 			if (itemDom.floating) {


### PR DESCRIPTION
Trying to fix the same issue as https://github.com/DataTables/FixedHeader/pull/104 but with a different approach.

On mobile, if the header or footer contains an input field, we have an issue where the mobile phone open and close the keyboard continuously on the input field focus.

This happens because when the keyboard opens, the resize event is triggered which is the event triggering the fixer header "redraw". The focus is lost during the redraw because the dom element is moved, and then, focus is reapplied to the previous active element. Which result in an infinite loop (re focusing the input will reopen the keyboard triggering resize event...).

With my fix, we skip the redraw if the fixed header is already properly positioned.